### PR TITLE
Add support for Apache Arrow Flight and user-defined ports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,3 @@
 PyModelarDB
 ===========
-`PyModelarDB <https://github.com/ModelarData/PyModelarDB>`_ is the official Python PEP-249 client for `ModelarDB <https://github.com/ModelarData/ModelarDB>`_.
+`PyModelarDB <https://github.com/ModelarData/PyModelarDB>`_ is the official Python PEP-249 client for `ModelarDB <https://github.com/ModelarData/ModelarDB>`_ and `MiniModelarDB <https://github.com/ModelarData/MiniModelarDB>`_.

--- a/pymodelardb/__init__.py
+++ b/pymodelardb/__init__.py
@@ -1,4 +1,4 @@
-"""The official Python PEP 249 client for ModelarDB"""
+"""The official Python PEP 249 client for ModelarDB and MiniModelarDB"""
 
 # Copyright 2021 The PyModelarDB Contributors
 #
@@ -16,7 +16,7 @@
 
 from pymodelardb import connection
 
-__version__ = '0.1'
+__version__ = '0.2'
 __all__ = ['apilevel', 'threadsafety', 'paramstyle', 'connection']
 
 apilevel = "2.0"

--- a/pymodelardb/connection.py
+++ b/pymodelardb/connection.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pymodelardb.types import Interface, NotSupportedError, ProgrammingError, DEFAULT_PORT_NUMBER
+from pymodelardb.types import Interface
+from pymodelardb.types import NotSupportedError
+from pymodelardb.types import ProgrammingError
+from pymodelardb.types import DEFAULT_PORT_NUMBER
 
 __all__ = ['Connection']
 
@@ -39,22 +42,22 @@ class Connection(object):
         :param port: the port number ModelarDB or MiniModelarDB is configured
         to used for its interface (defaults to 9999 if not specified).
     """
-    def __init__(self, dsn: str=None, user: str=None, password: str=None,
-                 host: str=None, database: str=None, interface: str=None,
-                 port: int=DEFAULT_PORT_NUMBER):
+    def __init__(self, dsn: str = None, user: str = None, password: str = None,
+                 host: str = None, database: str = None, interface: str = None,
+                 port: int = DEFAULT_PORT_NUMBER):
 
         # Ensure the necessary parameters have been provided
         if user or password or database:
             raise NotSupportedError(
-                    "only dsn, host, interface, and port is supported")
+                  "only dsn, host, interface, and port is supported")
         elif dsn:   # The connection string is given precedence
             try:
                 interface, hostAndMaybePort = dsn.split('://')
                 hostAndMaybePortSplit = hostAndMaybePort.split(':')
                 host = hostAndMaybePortSplit[0]
                 port = int(hostAndMaybePortSplit[1]) \
-                        if 1 < len(hostAndMaybePortSplit) \
-                        else DEFAULT_PORT_NUMBER
+                    if 1 < len(hostAndMaybePortSplit) \
+                    else DEFAULT_PORT_NUMBER
             except ValueError:
                 raise ProgrammingError(
                     "dsn must be interface://hostname-or-ip[:port]") from None

--- a/pymodelardb/cursors.py
+++ b/pymodelardb/cursors.py
@@ -141,7 +141,8 @@ class Cursor(object):
         description = []
         if result_set:
             for name, value in result_set[0].items():
-                type_code = TypeOf.STRING if value is str else TypeOf.NUMBER
+                type_code = TypeOf.STRING if type(value) is str \
+                        else TypeOf.NUMBER
                 description \
                     .append((name, type_code, None, None, None, None, False))
         self._description = tuple(description)

--- a/pymodelardb/cursors.py
+++ b/pymodelardb/cursors.py
@@ -169,8 +169,7 @@ class ArrowCursor(Cursor):
         self.__type_map = {
             pyarrow.string(): TypeOf.STRING,
             pyarrow.int32(): TypeOf.NUMBER,
-            pyarrow.timestamp('ms'): TypeOf.DATETIME,  # DataFusion and H2
-            pyarrow.timestamp('us', 'UTC'): TypeOf.DATETIME,  # Spark
+            pyarrow.timestamp('ms'): TypeOf.DATETIME,
             pyarrow.float32(): TypeOf.NUMBER,
             pyarrow.float64(): TypeOf.NUMBER,  # For testing
             pyarrow.binary(): TypeOf.BINARY

--- a/pymodelardb/types.py
+++ b/pymodelardb/types.py
@@ -18,6 +18,8 @@
 
 from enum import Enum
 
+DEFAULT_PORT_NUMBER = 9999
+
 
 class Error(Exception):
     """Base error for all other errors to derive from."""

--- a/pymodelardb/types.py
+++ b/pymodelardb/types.py
@@ -2,9 +2,23 @@
    instead of pymodelardb.__init__ to avoid circular dependencies.
 """
 
+# Copyright 2021 The PyModelarDB Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from enum import Enum
 
-# Public Types
+
 class Error(Exception):
     """Base error for all other errors to derive from."""
 
@@ -22,9 +36,11 @@ class NotSupportedError(DatabaseError):
 
 
 class Interface(Enum):
-    """The different interfaces ModelarDB supports."""
-    SOCKET = 1,
-    HTTP = 2,
+    """The different interfaces ModelarDB and MiniModelarDB supports."""
+    ARROW = 1
+    SOCKET = 2
+    HTTP = 3
+
 
 class TypeOf(Enum):
     """The different types description.type_of must match."""

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     author='Soeren Kejser Jensen',
     author_email='devel@kejserjensen.dk',
     packages=find_packages(),
+    install_requires=['pyarrow'],
     url='https://github.com/modelardata/pymodelardb',
     license='Apache License 2.0',
     description='Python PEP 249 Client for ModelarDB',

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -15,7 +15,7 @@ import unittest
 import socket
 
 from pymodelardb.connection import Connection
-from pymodelardb.types import ProgrammingError, NotSupportedError
+from pymodelardb.types import ProgrammingError, NotSupportedError, DEFAULT_PORT_NUMBER
 from pymodelardb.cursors import ArrowCursor, HTTPCursor, SocketCursor
 
 
@@ -25,7 +25,7 @@ class ConnectionTest(unittest.TestCase):
         # Mocks the Apache Arrow Flight, HTTP, and socket interface
         cls.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         cls.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        cls.socket.bind(("localhost", 9999))
+        cls.socket.bind(("localhost", DEFAULT_PORT_NUMBER))
         cls.socket.listen()
 
     @classmethod
@@ -49,6 +49,9 @@ class ConnectionTest(unittest.TestCase):
         cursor = conn.cursor()
         self.assertIsInstance(cursor, SocketCursor)
         cursor.close()
+
+    def test_construct_dsn_with_port_correct(self):
+        Connection("http://localhost:" + str(DEFAULT_PORT_NUMBER + 1))
 
     def test_construct_dsn_arrow_wrong_separator(self):
         with self.assertRaises(ProgrammingError):
@@ -95,6 +98,10 @@ class ConnectionTest(unittest.TestCase):
         cursor = conn.cursor()
         self.assertIsInstance(cursor, SocketCursor)
         cursor.close()
+
+    def test_construct_host_interface_with_port_correct(self):
+        Connection(host="localhost", interface="http",
+                port=DEFAULT_PORT_NUMBER + 1)
 
     def test_construct_host_interface_wrong_interface(self):
         with self.assertRaises(ProgrammingError):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -11,12 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import unittest
 import socket
 
 from pymodelardb.connection import Connection
-from pymodelardb.types import ProgrammingError, NotSupportedError, DEFAULT_PORT_NUMBER
-from pymodelardb.cursors import ArrowCursor, HTTPCursor, SocketCursor
+from pymodelardb.types import ProgrammingError
+from pymodelardb.types import NotSupportedError
+from pymodelardb.types import DEFAULT_PORT_NUMBER
+from pymodelardb.cursors import ArrowCursor
+from pymodelardb.cursors import HTTPCursor
+from pymodelardb.cursors import SocketCursor
 
 
 class ConnectionTest(unittest.TestCase):
@@ -101,7 +106,7 @@ class ConnectionTest(unittest.TestCase):
 
     def test_construct_host_interface_with_port_correct(self):
         Connection(host="localhost", interface="http",
-                port=DEFAULT_PORT_NUMBER + 1)
+                   port=DEFAULT_PORT_NUMBER + 1)
 
     def test_construct_host_interface_wrong_interface(self):
         with self.assertRaises(ProgrammingError):

--- a/tests/test_cursors.py
+++ b/tests/test_cursors.py
@@ -12,31 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import time
+import json
 import locale
 import unittest
 import threading
+from datetime import datetime
+
+import pyarrow
+from pyarrow import flight
+
 import socket
+
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 from pymodelardb.connection import Connection
 from pymodelardb.types import ProgrammingError, TypeOf
 
 
+def parse_ts(timestamp: str):
+    """Parse timestamps from str to datetime.datetime objects."""
+    return datetime.strptime(timestamp, '%Y-%m-%d %H:%M:%S.%f')
+
+
 class CursorTest(object):
     @classmethod
     def setUpClass(cls):
+        cls.encoding = locale.getpreferredencoding()
         cls.thread = threading.Thread(target=cls.start_server, args=())
         cls.run_server = True
         cls.thread.start()
-        cls.encoding = locale.getpreferredencoding()
+        # Ensure that the server runs without adding complexity to the tests
+        time.sleep(0.25)
 
     @classmethod
     def tearDownClass(cls):
         cls.run_server = False
         cls.thread.join()
 
+    def setUp(self):
+        self.connection = Connection(self.dsn)
+        self.cursor = self.connection.cursor()
+
     def tearDown(self):
-        # Ensure the cursor and connection is always closed
         try:
             self.cursor.close()
         except ProgrammingError:
@@ -79,13 +96,11 @@ class CursorTest(object):
         description = self.cursor.description
         self.assertEqual(len(description), 3)
         self.assertEqual(description[0],
-                         ('TID', TypeOf.NUMBER, None, None, None, None, False))
+                ('TID', TypeOf.NUMBER, None, None, None, None, False))
         self.assertEqual(description[1],
-                         ('TIMESTAMP',
-                          TypeOf.NUMBER, None, None, None, None, False))
+                ('TIMESTAMP', TypeOf.NUMBER, None, None, None, None, False))
         self.assertEqual(description[2],
-                         ('VALUE',
-                          TypeOf.NUMBER, None, None, None, None, False))
+                ('VALUE', TypeOf.NUMBER, None, None, None, None, False))
         self.assertEqual(self.cursor.rowcount, 3)
 
     def test_execute_select_rows_fetchone(self):
@@ -113,7 +128,7 @@ class CursorTest(object):
           "time": "PT0.008S",
           "query": "SELECT MIN(value) FROM DataPoint",
           "result":  [
-            {"MIN(VALUE)":"null"}
+            {"MIN(VALUE)":"NULL"}
           ]
         }
         """)
@@ -123,8 +138,7 @@ class CursorTest(object):
         self.test_execute_select_null()
         description = self.cursor.description
         self.assertEqual(len(description), 1)
-        self.assertEqual(description[0],
-                         ('MIN(VALUE)',
+        self.assertEqual(description[0], ('MIN(VALUE)',
                           TypeOf.NUMBER, None, None, None, None, False))
         self.assertEqual(self.cursor.rowcount, 1)
 
@@ -175,14 +189,126 @@ class CursorTest(object):
         self.cursor.setoutputsizes(37, 73)
 
 
+class ArrowFlightServer(flight.FlightServerBase):
+    def __init__(self, location):
+        super(ArrowFlightServer, self).__init__(location=location)
+
+    def do_get(self, _, ticket):
+        if ticket == flight.Ticket('ERROR'):
+            raise pyarrow.ArrowInvalid('an error has occurred')
+        return flight.RecordBatchStream(self.response)
+
+
+class ArrowCursorTest(CursorTest, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.thread = threading.Thread(target=cls.start_server, args=())
+        cls.thread.start()
+        # Ensure that the server runs without adding complexity to the tests
+        time.sleep(0.25) 
+
+    @classmethod
+    def start_server(cls):
+        # Mock ModelarDB's and MiniModelarDB's Apache Arrow Flight interface
+        cls.dsn = "arrow://localhost"
+        cls.server = ArrowFlightServer(location="grpc://localhost:9999")
+        cls.server.response = None
+        cls.server.serve()
+
+    @classmethod
+    def set_server_response(cls, response: str):
+        rows = json.loads(response)['result']
+
+        # Values are float64 instead of float32 so assertEqual can be used
+        if not rows[0]:   # The result set contains no columns
+            columns = []
+        elif len(rows[0]) == 1:  # The result set contains aggregates
+            columns = [(next(iter(rows[0])), pyarrow.float64())]
+        elif len(rows[0]) == 3:  # The result set contains data points
+            columns = [('TID', pyarrow.int32()), ('TIMESTAMP',
+                pyarrow.timestamp('ms')), ('VALUE', pyarrow.float64())]
+        else:
+            raise ValueError("unknown schema")
+        schema = pyarrow.schema(columns)
+
+        columns = {}
+        for row in rows:
+            for name, value in row.items():
+                column = columns.get(name, [])
+
+                if name == 'TIMESTAMP':
+                    column.append(parse_ts(value))
+                elif value == 'NULL':
+                    column.append(None)
+                else:
+                    column.append(value)
+                columns[name] = column
+
+        columns = list(map(lambda name: columns[name], schema.names))
+        cls.server.response = pyarrow.table(columns, schema)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.thread.join()
+
+    def test_execute_select_error(self):
+        with self.assertRaises(ProgrammingError):
+            self.cursor.execute("ERROR")
+
+    def test_execute_select_rows_metadata(self):
+        self.test_execute_select_rows()
+        description = self.cursor.description
+        self.assertEqual(len(description), 3)
+        self.assertEqual(description[0],
+                ('TID', TypeOf.NUMBER, None, None, None, None, False))
+        self.assertEqual(description[1],
+                ('TIMESTAMP', TypeOf.DATETIME, None, None, None, None, False))
+        self.assertEqual(description[2],
+                ('VALUE', TypeOf.NUMBER, None, None, None, None, False))
+        self.assertEqual(self.cursor.rowcount, -1)
+
+    def test_execute_select_rows_fetchone(self):
+        self.test_execute_select_rows()
+        self.assertEqual(self.cursor.fetchone(),
+                         (1, parse_ts('1990-05-01 12:00:00.0'), 0.37))
+
+    def test_execute_select_rows_fetchmany(self):
+        self.test_execute_select_rows()
+        self.assertEqual(self.cursor.fetchmany(37),
+                         [(1, parse_ts('1990-05-01 12:00:00.0'), 0.37),
+                          (2, parse_ts('1990-05-01 12:00:00.0'), 0.55),
+                          (3, parse_ts('1990-05-01 12:00:00.0'), 0.73)])
+
+    def test_execute_select_rows_fetchall(self):
+        self.test_execute_select_rows()
+        self.assertEqual(self.cursor.fetchall(),
+                         [(1, parse_ts('1990-05-01 12:00:00.0'), 0.37),
+                          (2, parse_ts('1990-05-01 12:00:00.0'), 0.55),
+                          (3, parse_ts('1990-05-01 12:00:00.0'), 0.73)])
+
+    def test_execute_select_null_metadata(self):
+        self.test_execute_select_null()
+        description = self.cursor.description
+        self.assertEqual(len(description), 1)
+        self.assertEqual(description[0], ('MIN(VALUE)',
+                          TypeOf.NUMBER, None, None, None, None, False))
+        self.assertEqual(self.cursor.rowcount, -1)
+
+    def test_execute_select_empty_metadata(self):
+        self.test_execute_select_empty()
+        self.assertEqual(len(self.cursor.description), 0)
+        self.assertEqual(self.cursor.rowcount, -1)
+
+
 class TestHTTPRequestHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         self.send_response(200)
         self.send_header('Content-type', 'application/json')
         self.end_headers()
         self.wfile.write(self.response)
-        time.sleep(0.25)  # Ensure that the response is read without
-                          # adding unnecessary complexity to the tests
+        time.sleep(0.25)   # Ensure that the response is read without
+                           # adding unnecessary complexity to the tests
 
     def log_message(self, format, *args):
         pass  # Stop messages being written to stdout
@@ -190,12 +316,9 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
 
 class HTTPCursorTest(CursorTest, unittest.TestCase):
     @classmethod
-    def set_server_response(cls, response: str):
-        cls.handler.response = response.encode(cls.encoding)
-
-    @classmethod
     def start_server(cls):
         # Mock ModelarDB's HTTP interface
+        cls.dsn = "http://localhost"
         HTTPServer.allow_reuse_address = True
         cls.handler = TestHTTPRequestHandler
         cls.server = HTTPServer(("localhost", 9999), cls.handler)
@@ -206,19 +329,16 @@ class HTTPCursorTest(CursorTest, unittest.TestCase):
             cls.server.handle_request()
         cls.server.server_close()
 
-    def setUp(self):
-        self.connection = Connection("http://localhost")
-        self.cursor = self.connection.cursor()
+    @classmethod
+    def set_server_response(cls, response: str):
+        cls.handler.response = response.encode(cls.encoding)
 
 
 class SocketCursorTest(CursorTest, unittest.TestCase):
     @classmethod
-    def set_server_response(cls, response: str):
-        cls.response = response.encode(cls.encoding)
-
-    @classmethod
     def start_server(cls):
         # Mock ModelarDB's Socket interface
+        cls.dsn = "socket://localhost"
         cls.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         cls.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         cls.socket.bind(("localhost", 9999))
@@ -232,6 +352,6 @@ class SocketCursorTest(CursorTest, unittest.TestCase):
             conn.close()      # adding unnecessary complexity to the tests
         cls.socket.close()
 
-    def setUp(self):
-        self.connection = Connection("socket://localhost")
-        self.cursor = self.connection.cursor()
+    @classmethod
+    def set_server_response(cls, response: str):
+        cls.response = response.encode(cls.encoding)

--- a/tests/test_cursors.py
+++ b/tests/test_cursors.py
@@ -26,7 +26,7 @@ import socket
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 from pymodelardb.connection import Connection
-from pymodelardb.types import ProgrammingError, TypeOf
+from pymodelardb.types import ProgrammingError, TypeOf, DEFAULT_PORT_NUMBER
 
 
 def parse_ts(timestamp: str):
@@ -211,7 +211,8 @@ class ArrowCursorTest(CursorTest, unittest.TestCase):
     def start_server(cls):
         # Mock ModelarDB's and MiniModelarDB's Apache Arrow Flight interface
         cls.dsn = "arrow://localhost"
-        cls.server = ArrowFlightServer(location="grpc://localhost:9999")
+        location = "grpc://localhost:" + str(DEFAULT_PORT_NUMBER)
+        cls.server = ArrowFlightServer(location)
         cls.server.response = None
         cls.server.serve()
 
@@ -321,7 +322,7 @@ class HTTPCursorTest(CursorTest, unittest.TestCase):
         cls.dsn = "http://localhost"
         HTTPServer.allow_reuse_address = True
         cls.handler = TestHTTPRequestHandler
-        cls.server = HTTPServer(("localhost", 9999), cls.handler)
+        cls.server = HTTPServer(("localhost", DEFAULT_PORT_NUMBER), cls.handler)
         cls.server.timeout = 0.20
         cls.response = b""
 
@@ -341,7 +342,7 @@ class SocketCursorTest(CursorTest, unittest.TestCase):
         cls.dsn = "socket://localhost"
         cls.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         cls.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        cls.socket.bind(("localhost", 9999))
+        cls.socket.bind(("localhost", DEFAULT_PORT_NUMBER))
         cls.socket.listen()
         cls.response = b""
 

--- a/tests/test_cursors.py
+++ b/tests/test_cursors.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import time
 import json
 import locale
@@ -23,10 +24,13 @@ from pyarrow import flight
 
 import socket
 
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import HTTPServer
+from http.server import BaseHTTPRequestHandler
 
 from pymodelardb.connection import Connection
-from pymodelardb.types import ProgrammingError, TypeOf, DEFAULT_PORT_NUMBER
+from pymodelardb.types import ProgrammingError
+from pymodelardb.types import TypeOf
+from pymodelardb.types import DEFAULT_PORT_NUMBER
 
 
 def parse_ts(timestamp: str):
@@ -95,12 +99,12 @@ class CursorTest(object):
         self.test_execute_select_rows()
         description = self.cursor.description
         self.assertEqual(len(description), 3)
-        self.assertEqual(description[0],
-                ('TID', TypeOf.NUMBER, None, None, None, None, False))
-        self.assertEqual(description[1],
-                ('TIMESTAMP', TypeOf.NUMBER, None, None, None, None, False))
-        self.assertEqual(description[2],
-                ('VALUE', TypeOf.NUMBER, None, None, None, None, False))
+        self.assertEqual(description[0], ('TID',
+                         TypeOf.NUMBER, None, None, None, None, False))
+        self.assertEqual(description[1], ('TIMESTAMP',
+                         TypeOf.STRING, None, None, None, None, False))
+        self.assertEqual(description[2], ('VALUE',
+                         TypeOf.NUMBER, None, None, None, None, False))
         self.assertEqual(self.cursor.rowcount, 3)
 
     def test_execute_select_rows_fetchone(self):
@@ -139,7 +143,7 @@ class CursorTest(object):
         description = self.cursor.description
         self.assertEqual(len(description), 1)
         self.assertEqual(description[0], ('MIN(VALUE)',
-                          TypeOf.NUMBER, None, None, None, None, False))
+                         TypeOf.STRING, None, None, None, None, False))
         self.assertEqual(self.cursor.rowcount, 1)
 
     def test_execute_select_empty(self):
@@ -205,7 +209,7 @@ class ArrowCursorTest(CursorTest, unittest.TestCase):
         cls.thread = threading.Thread(target=cls.start_server, args=())
         cls.thread.start()
         # Ensure that the server runs without adding complexity to the tests
-        time.sleep(0.25) 
+        time.sleep(0.25)
 
     @classmethod
     def start_server(cls):
@@ -227,7 +231,7 @@ class ArrowCursorTest(CursorTest, unittest.TestCase):
             columns = [(next(iter(rows[0])), pyarrow.float64())]
         elif len(rows[0]) == 3:  # The result set contains data points
             columns = [('TID', pyarrow.int32()), ('TIMESTAMP',
-                pyarrow.timestamp('ms')), ('VALUE', pyarrow.float64())]
+                       pyarrow.timestamp('ms')), ('VALUE', pyarrow.float64())]
         else:
             raise ValueError("unknown schema")
         schema = pyarrow.schema(columns)
@@ -261,12 +265,12 @@ class ArrowCursorTest(CursorTest, unittest.TestCase):
         self.test_execute_select_rows()
         description = self.cursor.description
         self.assertEqual(len(description), 3)
-        self.assertEqual(description[0],
-                ('TID', TypeOf.NUMBER, None, None, None, None, False))
-        self.assertEqual(description[1],
-                ('TIMESTAMP', TypeOf.DATETIME, None, None, None, None, False))
-        self.assertEqual(description[2],
-                ('VALUE', TypeOf.NUMBER, None, None, None, None, False))
+        self.assertEqual(description[0], ('TID',
+                         TypeOf.NUMBER, None, None, None, None, False))
+        self.assertEqual(description[1], ('TIMESTAMP',
+                         TypeOf.DATETIME, None, None, None, None, False))
+        self.assertEqual(description[2], ('VALUE',
+                         TypeOf.NUMBER, None, None, None, None, False))
         self.assertEqual(self.cursor.rowcount, -1)
 
     def test_execute_select_rows_fetchone(self):
@@ -293,7 +297,7 @@ class ArrowCursorTest(CursorTest, unittest.TestCase):
         description = self.cursor.description
         self.assertEqual(len(description), 1)
         self.assertEqual(description[0], ('MIN(VALUE)',
-                          TypeOf.NUMBER, None, None, None, None, False))
+                         TypeOf.NUMBER, None, None, None, None, False))
         self.assertEqual(self.cursor.rowcount, -1)
 
     def test_execute_select_empty_metadata(self):
@@ -308,8 +312,8 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
         self.send_header('Content-type', 'application/json')
         self.end_headers()
         self.wfile.write(self.response)
-        time.sleep(0.25)   # Ensure that the response is read without
-                           # adding unnecessary complexity to the tests
+        # Ensure the response is read without adding complexity to the test
+        time.sleep(0.25)
 
     def log_message(self, format, *args):
         pass  # Stop messages being written to stdout
@@ -322,7 +326,8 @@ class HTTPCursorTest(CursorTest, unittest.TestCase):
         cls.dsn = "http://localhost"
         HTTPServer.allow_reuse_address = True
         cls.handler = TestHTTPRequestHandler
-        cls.server = HTTPServer(("localhost", DEFAULT_PORT_NUMBER), cls.handler)
+        cls.server = HTTPServer(
+            ("localhost", DEFAULT_PORT_NUMBER), cls.handler)
         cls.server.timeout = 0.20
         cls.response = b""
 
@@ -349,8 +354,9 @@ class SocketCursorTest(CursorTest, unittest.TestCase):
         while cls.run_server:
             conn, _ = cls.socket.accept()
             conn.sendall(cls.response)
-            time.sleep(0.25)  # Ensure that the response is read without
-            conn.close()      # adding unnecessary complexity to the tests
+            # Ensure the response is read without adding complexity to the test
+            time.sleep(0.25)
+            conn.close()
         cls.socket.close()
 
     @classmethod


### PR DESCRIPTION
Support for querying [ModelarDB](https://github.com/ModelarData/ModelarDB) and [MiniModelarDB](https://github.com/ModelarData/MiniModelarDB) using Apache Arrow Flight ([pyarrow](https://arrow.apache.org/docs/python/index.html)) have been added. [ArrowCursor](https://github.com/ModelarData/PyModelarDB/blob/dev/add-arrow-flight/pymodelardb/cursors.py#L164) uses a [generator function](https://github.com/ModelarData/PyModelarDB/blob/dev/add-arrow-flight/pymodelardb/cursors.py#L214) to only retrieve the next chunk of a result set when one of the rows it contains is fetched by the user. The size of each chunk is currently statically set by [ModelarDB](https://github.com/ModelarData/ModelarDB/blob/dev/refactor-data-transfer/src/main/scala/dk/aau/modelardb/remote/ArrowResultSet.scala#L27) and MiniModelarDB. In addition, the port to use can now optionally be set by the user when a [Connection](https://github.com/ModelarData/PyModelarDB/blob/dev/add-arrow-flight/pymodelardb/connection.py#L47) is created.