### PR TITLE
Add GitHub Action for running Python unittest

### DIFF
--- a/.github/workflows/python-unittest-on-pr-and-push.yml
+++ b/.github/workflows/python-unittest-on-pr-and-push.yml
@@ -1,0 +1,20 @@
+name: Python unittest
+
+on:
+  pull_request:
+    branches: [ "master" ]
+  push:
+    branches: [ "master" ]
+
+jobs:
+  python_unittest:
+    name: Python unittest
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install PyArrow
+      run: pip3 install pyarrow
+    - name: Python unittest
+      run: python3 -m unittest --verbose

--- a/pymodelardb/cursors.py
+++ b/pymodelardb/cursors.py
@@ -189,11 +189,10 @@ class ArrowCursor(Cursor):
                                    self.__uri) from None
         except ArrowException as ae:
             error = ae.args[0]
-            start_of_error = error.find('{')
-            end_of_error = error.rfind('}') + 1
-            error = json.loads(error[start_of_error: end_of_error])
-            message = 'unable to execute query due to: ' \
-                + error['grpc_message'].strip()
+            start_of_error = error.find('{') + 1
+            end_of_error = error.rfind('}')
+            error = error[start_of_error: end_of_error]
+            message = 'unable to execute query due to: ' + error
             raise ProgrammingError(message) from None
 
     def _after_execute(self, response: FlightStreamReader):


### PR DESCRIPTION
This PR fixes a minor misunderstanding of what format PyArrow uses for errors and adds a GitHub Action workflow that automatically runs `python3 -m unittest` on PRs and pushes to `master`.