### PR TITLE
Change master to main in GitHub Actions

### DIFF
--- a/.github/workflows/python-unittest-on-pr-and-push.yml
+++ b/.github/workflows/python-unittest-on-pr-and-push.yml
@@ -2,9 +2,9 @@ name: Python unittest
 
 on:
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   python_unittest:


### PR DESCRIPTION
This PR changes `master` to `main` in GitHub Actions.